### PR TITLE
[Dev] Implement blocksparse attention

### DIFF
--- a/attention_engine/attn_engine/attn_engine.py
+++ b/attention_engine/attn_engine/attn_engine.py
@@ -202,7 +202,7 @@ class AttentionEngine:
                                       online_func,
                                       custom_fwd_inputs,
                                       qkv_meta[0].shape[0], # B
-                                        qkv_meta[0].shape[1], # H
+                                        head_kv, # H
                                         kv_len, # S
                                       qkv_meta[0].shape[3],
                                       qkv_meta[2].shape[3],

--- a/attention_engine/attn_engine/attn_engine.py
+++ b/attention_engine/attn_engine/attn_engine.py
@@ -248,6 +248,8 @@ class AttentionEngine:
         self.attention = tl_attn.attention
         if infer_mask:
             self.block_mask = block_mask
+        else:
+            self.block_mask = None
 
     def __call__(self, *args, **kargs):
         if self.block_mask is not None:

--- a/attention_engine/benchmark/bench_utils.py
+++ b/attention_engine/benchmark/bench_utils.py
@@ -1174,9 +1174,11 @@ def bench_retention_fwd(attn, B, H, S, D, DV, dtype=torch.bfloat16):
 
 
 def do_bench_attention(attn, B, H, S, D, DV, mod=None, dtype=torch.float16,
-                       seqlenq=None, require_grad=False, causal=True):
+                       seqlenq=None, require_grad=False, causal=True, groupnum=None):
     if seqlenq is None:
         seqlenq = S
+    if groupnum is None:
+        groupnum = H
     tflops = 2 * B * H * seqlenq * S * D + 2 * B * H * seqlenq * S * DV
     tflops = tflops * 0.5 if causal else tflops
     bwd_tflops = 4 * B * H * S * S * DV + 6 * B * H * S * S * D
@@ -1190,10 +1192,10 @@ def do_bench_attention(attn, B, H, S, D, DV, mod=None, dtype=torch.float16,
         B, seqlenq, H, D, device=device, dtype=dtype, requires_grad=require_grad
     )
     key = torch.randn(
-        B, S, H, D, device=device, dtype=dtype, requires_grad=require_grad
+        B, S, groupnum, D, device=device, dtype=dtype, requires_grad=require_grad
     )
     value = torch.randn(
-        B, S, H, DV, device=device, dtype=dtype, requires_grad=require_grad
+        B, S, groupnum, DV, device=device, dtype=dtype, requires_grad=require_grad
     )
     do = torch.randn(
         B, seqlenq, H, DV, device=device, dtype=dtype, requires_grad=False

--- a/attention_engine/core/blockattn_template.py
+++ b/attention_engine/core/blockattn_template.py
@@ -1,0 +1,32 @@
+import jinja2
+import os
+import os.path as osp
+
+TEMPLATE_DIR = osp.join(
+    osp.dirname(
+        osp.abspath(__file__)),
+    'tl_template/attn/blockattn_tl.py')
+
+
+class TlBlockAttnTemplate:
+    def __init__(self, template_dir=TEMPLATE_DIR,
+                 **kargs
+                 ):
+        with open(template_dir, 'r') as f:
+            TL_KERNEL = f.read()
+
+        template = jinja2.Template(TL_KERNEL)
+
+        # remove None
+        kargs = {k: (v if v is not None else "") for k, v in kargs.items()}
+        self.tlcode = template.render(**kargs)
+
+    def __call__(self):
+        return self.tlcode
+
+
+if __name__ == "__main__":
+    tl_code = TlAttnTemplate()()
+    print(tl_code)
+    exec(tl_code)
+    print(attention)

--- a/attention_engine/core/core.py
+++ b/attention_engine/core/core.py
@@ -444,3 +444,9 @@ def create_block_mask(mask_mod, B, H, QLen, KVLen, device, Q_BLOCK_SIZE=None, KV
     # TODO: sparse block
     
     return partial_block_mask
+
+def create_block_idx(mask_mod, B, H, QLen, KVLen, device, Q_BLOCK_SIZE=None, KV_BLOCK_SIZE=None):
+    block_mask = create_block_mask(mask_mod, B, H, QLen, KVLen, device, Q_BLOCK_SIZE, KV_BLOCK_SIZE)
+    block_idx = torch.nonzero(block_mask, as_tuple=False)
+    # TODO
+    return block_idx

--- a/attention_engine/core/core.py
+++ b/attention_engine/core/core.py
@@ -407,7 +407,7 @@ def is_causal_mask(mask_tensor, block_M, block_N):
     # 创建一个下三角掩码
     mask = (q_idx+1)*block_M > kv_idx*block_N
     # 判断是否相等
-    return torch.all(mask_tensor.bool() == mask)
+    return torch.all(mask_tensor.bool() == mask.to(mask_tensor.device))
 
 def is_less_causal_mask(mask_tensor, block_M, block_N):
     """

--- a/attention_engine/core/core.py
+++ b/attention_engine/core/core.py
@@ -6,6 +6,9 @@ from .utils import IndentedCode
 import functools
 from copy import copy, deepcopy
 
+from torch import Tensor
+from typing import Optional, Union, Any
+
 # TODO: support online_func extern_input_tensor
 
 
@@ -286,5 +289,158 @@ class CustomIO:
         return decorator
 
 
-def create_block_mask(causal_mask, B, H, QLen, KVLen, device):
-    return True
+def create_mask(
+    mod_fn,
+    B: Optional[int],
+    H: Optional[int],
+    Q_LEN: int,
+    KV_LEN: int,
+    device: str = "cuda",
+) -> torch.Tensor:
+    r"""This function creates a mask tensor from a mod_fn function.
+
+    Args:
+        mod_fn (Union[_score_mod_signature, _mask_mod_signature]): Function to modify attention scores.
+        B (int): Batch size.
+        H (int): Number of query heads.
+        Q_LEN (int): Sequence length of query.
+        KV_LEN (int): Sequence length of key/value.
+        device (str): Device to run the mask creation on.
+
+    Returns:
+        mask (Tensor): A mask tensor with shape (B, H, M, N).
+    """
+    if B is None:
+        B = 1
+    if H is None:
+        H = 1
+    b = torch.arange(0, B, device=device)
+    h = torch.arange(0, H, device=device)
+    m = torch.arange(0, Q_LEN, device=device)
+    n = torch.arange(0, KV_LEN, device=device)
+
+    # with TransformGetItemToIndex():
+    #     # elif mod_type == _ModificationType.MASK_MOD:
+    #     mask_mod = mod_fn
+    #     mask_mod = _vmap_for_bhqkv(mask_mod, prefix=())
+    #     mask = mask_mod(b, h, m, n)
+    #     return mask
+    
+    dimensions = [
+        (None, None, None, 0),
+        (None, None, 0, None),
+        (None, 0, None, None),
+        (0, None, None, None),
+    ]
+    for dim in dimensions:
+        mod_fn = torch.vmap(mod_fn, in_dims=dim, out_dims=0)
+    mask = mod_fn(b, h, m, n)
+    return mask
+
+_DEFAULT_SPARSE_BLOCK_SIZE = 128
+
+def _broadcast_to_dim(x, dim):
+    while x.dim() < dim:
+        x = x.unsqueeze(0)
+    return x
+
+def _round_up_to_multiple(x, multiple):
+    return (x + multiple - 1) // multiple * multiple
+
+def _convert_mask_to_block_mask(
+    mask: torch.Tensor,
+    Q_BLOCK_SIZE=_DEFAULT_SPARSE_BLOCK_SIZE,
+    KV_BLOCK_SIZE=_DEFAULT_SPARSE_BLOCK_SIZE,
+    separate_full_blocks: bool = False,
+) -> tuple[Tensor, Optional[Tensor]]:
+    assert mask.dtype == torch.bool
+    mask = _broadcast_to_dim(mask, 4)
+
+    def padding_needed_for_multiple(x, multiple):
+        return _round_up_to_multiple(x, multiple) - x
+
+    mask = torch.nn.functional.pad(
+        mask,
+        (
+            0,
+            padding_needed_for_multiple(mask.shape[-1], KV_BLOCK_SIZE),
+            0,
+            padding_needed_for_multiple(mask.shape[-2], Q_BLOCK_SIZE),
+        ),
+    )
+    B, H, Q, KV = mask.shape
+    assert Q % Q_BLOCK_SIZE == 0
+    assert KV % KV_BLOCK_SIZE == 0
+    mask = mask.view(
+        B, H, Q // Q_BLOCK_SIZE, Q_BLOCK_SIZE, KV // KV_BLOCK_SIZE, KV_BLOCK_SIZE
+    )  # [B, H, Q//Q_BLOCK_SIZE, Q_BLOCK_SIZE, KV//KV_BLOCK_SIZE, KV_BLOCK_SIZE]
+    mask = mask.permute(
+        0, 1, 2, 4, 3, 5
+    )  # [B, H, Q//Q_BLOCK_SIZE, KV//KV_BLOCK_SIZE, Q_BLOCK_SIZE, KV_BLOCK_SIZE]
+    mask_block_sum = mask.sum(
+        dim=[-2, -1]
+    )  # [B, H, Q//Q_BLOCK_SIZE, KV//KV_BLOCK_SIZE]
+    if separate_full_blocks:
+        full_block_sum = Q_BLOCK_SIZE * KV_BLOCK_SIZE
+        full_blocks = mask_block_sum == full_block_sum
+        partial_blocks = (mask_block_sum > 0) & (mask_block_sum < full_block_sum)
+        partial_blocks = partial_blocks.to(dtype=torch.int8)
+        full_blocks = full_blocks.to(dtype=torch.int8)
+        return partial_blocks, full_blocks
+    else:
+        partial_blocks = mask_block_sum > 0
+        partial_blocks = partial_blocks.to(dtype=torch.int8)
+        return partial_blocks, None
+
+def is_causal_mask(mask_tensor, block_M, block_N):
+    """
+    mask_tensor: (B,H,seqlen//BLOCKM,seqlen//BLOCKN)
+    
+    return:
+    True: mask_tensor is a causal mask
+    False: mask_tensor is not a causal mask
+    """
+    # 获取张量的形状
+    B, H, M, N = mask_tensor.shape
+    q_idx = torch.arange(M).unsqueeze(-1)  # 创建一个列向量
+    kv_idx = torch.arange(N).view(1,-1)  # 创建一个行向量
+    # 创建一个下三角掩码
+    mask = (q_idx+1)*block_M > kv_idx*block_N
+    # 判断是否相等
+    return torch.all(mask_tensor.bool() == mask)
+
+def is_less_causal_mask(mask_tensor, block_M, block_N):
+    """
+    mask_tensor: (B,H,seqlen//BLOCKM,seqlen//BLOCKN)
+    
+    return:
+    True: mask_tensor is a less causal mask
+    False: mask_tensor is not a less causal mask
+    """
+    # 获取张量的形状
+    B, H, M, N = mask_tensor.shape
+    q_idx = torch.arange(M).unsqueeze(-1)  # 创建一个列向量
+    kv_idx = torch.arange(N).view(1,-1)  # 创建一个行向量
+    # 创建一个上三角掩码
+    mask = (q_idx+1)*block_M-1 < (kv_idx)*block_N
+    filter_tensor = mask_tensor[...,mask]
+    is_all_zero = torch.all(filter_tensor == 0)
+    return is_all_zero
+
+
+BLOCK_SIZE = 128
+def create_block_mask(mask_mod, B, H, QLen, KVLen, device, Q_BLOCK_SIZE=None, KV_BLOCK_SIZE=None):
+    if Q_BLOCK_SIZE is None:
+        Q_BLOCK_SIZE = BLOCK_SIZE
+    if KV_BLOCK_SIZE is None:
+        KV_BLOCK_SIZE = BLOCK_SIZE
+    mask_tensor = create_mask(mask_mod, B, H, QLen, KVLen, device)
+    partial_block_mask, full_block_mask = _convert_mask_to_block_mask(
+        mask_tensor,
+        Q_BLOCK_SIZE=Q_BLOCK_SIZE,
+        KV_BLOCK_SIZE=KV_BLOCK_SIZE,
+        separate_full_blocks=False,
+    )
+    # TODO: sparse block
+    
+    return partial_block_mask

--- a/attention_engine/core/lower_decode_gqa.py
+++ b/attention_engine/core/lower_decode_gqa.py
@@ -1,0 +1,568 @@
+# from ..attn_engine import OnlineFunc
+from .core import SymbolScalar, SymbolicArray, CustomIO, create_block_mask
+from .graph import Var, Const
+from .utils import IndentedCode
+from .tl_gen import generate_tl_from_dag
+from .attn_template import TlAttnTemplate
+from dataclasses import dataclass
+
+import torch
+import os
+import os.path as osp
+THIS_FILE_PATH = osp.dirname(osp.abspath(__file__))
+TEMPLATE_PATH = osp.join(
+    THIS_FILE_PATH,
+    "tl_template/attn/attn_gqa_inference_tl.py")
+
+# TODO: bwd map
+shape_idx_map = {
+    "batch": "bid",
+    "heads": "hid",
+    "seq_len": "mid*block_M:(mid+1)*block_M",
+    "seq_len_kv": "(seq_len_kv // num_split) * sid + k * block_N : (seq_len_kv // num_split) * sid + (k + 1) * block_N",
+    "1": "0"
+    # others: ":" -> ":"
+}
+shape_idx_onchip_map = {
+    "batch": "",
+    "heads": "",
+    "seq_len": "block_M",
+    "seq_len_kv": "block_N",
+    "1": ""
+}
+shape_idx_map_bwd = {
+    "batch": "bz",
+    "heads": "by",
+    "seq_len": "k*block_N:(k+1)*block_N",
+    "seq_len_kv": "bx*block_M:(bx+1)*block_M",
+    "1": "0"
+}
+shape_idx_onchip_map_bwd = {
+    "batch": "",
+    "heads": "",
+    "seq_len": "block_N",
+    "seq_len_kv": "block_M",
+    "1": ""
+}
+
+RECURRENT_DIM = "block_N"
+
+
+@dataclass
+class lowerOutput:
+    swizzle_shared: str = ""
+    tl_dtype: str = "float16"
+    is_inf_mask: str = "True"
+
+
+@dataclass
+class TunnerOutput:
+    block_M: str = "64"
+    block_N: str = "64"
+    stages: str = "2"
+    thread_num: str = "256"
+    shared_fuse: str = "False"
+
+
+class lowerOnlineFuncOutput:
+
+    def __init__(self, final_rowscales_list, final_rowscales_output, final_rowscales_init, torch_alloc_final_rowscales, online_rowscales_initvalue, online_func_init, online_func_inputs, online_func_body, online_func_inputs_list, o_scale, online_func_epilogue, final_rowscales_save,
+                 online_rowscales_update,
+                 isused_doosum, final_rowscales_length, final_rowscales_load, online_func_fwd, custom_bwd_inputs_load, custom_bwd_body,
+                 final_rowscales_shared_init,
+                 custom_bwd_inputs, custom_bwd_inputs_init,
+                 o_scale_varname):
+        self.final_rowscales_list = final_rowscales_list
+        self.final_rowscales_output = final_rowscales_output
+        self.final_rowscales_init = final_rowscales_init
+        self.torch_alloc_final_rowscales = torch_alloc_final_rowscales
+        self.online_rowscales_initvalue = online_rowscales_initvalue
+        self.online_func_init = online_func_init
+        self.online_func_inputs = online_func_inputs
+        self.online_func_body = online_func_body
+        self.online_func_inputs_list = online_func_inputs_list
+        self.o_scale = o_scale
+        self.online_func_epilogue = online_func_epilogue
+        self.final_rowscales_save = final_rowscales_save
+        self.online_rowscales_update = online_rowscales_update
+
+        self.isused_doosum = isused_doosum
+        self.final_rowscales_length = final_rowscales_length
+        self.final_rowscales_load = final_rowscales_load
+        self.online_func_fwd = online_func_fwd
+        self.custom_bwd_inputs_load = custom_bwd_inputs_load
+        self.custom_bwd_body = custom_bwd_body
+        self.final_rowscales_shared_init = final_rowscales_shared_init
+        self.custom_bwd_inputs = custom_bwd_inputs
+        self.custom_bwd_inputs_init = custom_bwd_inputs_init
+        self.o_scale_varname = o_scale_varname
+
+
+class lowerScoreModOutput:
+    def __init__(self, score_mod_inputs, score_mod_body, score_mod_inputs_list,
+                 score_mod_backward,
+                 score_mod_bwd_inputs_list,
+                 score_mod_bwd_inputs,
+                 score_mod_inputs_bwd_list,
+                 score_mod_fwd_inputs,
+                 score_mod_fwd_body,
+                 score_mod_output_var,
+                 score_mod_bwd_inputs_declare,
+                 score_mod_bwd_inputs_declare_shared
+                 ):
+        self.score_mod_inputs = score_mod_inputs
+        self.score_mod_body = score_mod_body
+        self.score_mod_inputs_list = score_mod_inputs_list
+        self.score_mod_backward = score_mod_backward
+        self.score_mod_bwd_inputs = score_mod_bwd_inputs
+        self.score_mod_bwd_inputs_list = score_mod_bwd_inputs_list
+        self.score_mod_inputs_bwd_list = score_mod_inputs_bwd_list
+        self.score_mod_fwd_inputs = score_mod_fwd_inputs
+        self.score_mod_fwd_body = score_mod_fwd_body
+        self.score_mod_output_var = score_mod_output_var
+        self.score_mod_bwd_inputs_declare = score_mod_bwd_inputs_declare
+        self.score_mod_bwd_inputs_declare_shared = score_mod_bwd_inputs_declare_shared
+
+
+def lower_online_func(online_func, lower_output: lowerOutput,
+                      scores_name="scores"):  # OnlineFunc):
+    online_fwd = online_func.online_fwd
+    scores = SymbolicArray(
+        scores_name,
+        Var(scores_name),
+        shape_idx=[
+            "block_M",
+            "block_N"])
+    online_rowscales = online_func.online_rowscales
+    b = SymbolScalar("b", Var("b"))
+    h = SymbolScalar("h", Var("h"))
+    q_idx = SymbolScalar("q_idx", Var("q_idx"))
+
+    # online&epilogue
+    input_vars = {}
+
+    # generate init value for online_rowscales
+    online_rowscales_initvalue = ""
+    for k, v in online_rowscales.items():  # v.code is Var
+        if v.code.name == "-inf":
+            tl_init_value = "-T.infinity(accum_dtype)"
+        else:
+            tl_init_value = v.code.name
+        online_rowscales_initvalue += f"T.fill({v.varname}, {tl_init_value})\n"
+
+    # online_fwd
+    scores_new, new_online_rowscales, o_scalevar = online_fwd(
+        scores, online_rowscales, b, h, q_idx)
+    for k, v in new_online_rowscales.items():
+        new_online_rowscales[k].count += 1
+    o_scalevar.count += 1
+    tl_code, input_vars_online = generate_tl_from_dag(
+        list(new_online_rowscales.values()) + [scores_new, o_scalevar])
+    online_func_body = str(tl_code)
+    if online_func_body == "":
+        online_func_body = "pass"
+    online_func_inputs = ""
+    for varname, input_var in input_vars_online.items():
+        online_func_inputs += f"{input_var.varname}: T.Buffer([{', '.join(input_var.shape_idx)}], accum_dtype), \n"
+    online_func_inputs_list = ", ".join(
+        [input_var.varname for varname, input_var in input_vars_online.items()])
+    input_vars.update(input_vars_online)
+    # o_scale = o_scalevar.varname
+    o_scale_varname = o_scalevar.varname
+    o_scale = IndentedCode()
+    o_scale.add_line(f"for i, j in T.Parallel(block_M, dimv):")
+    o_scale.more_indent()
+    o_scale.add_line(f"acc_o[i, j] *= {o_scalevar.varname}[i]")
+    o_scale = str(o_scale)
+
+    online_rowscales_update = ""
+    for k, v in new_online_rowscales.items():
+        if v.varname == k:
+            continue
+        online_rowscales_update += f"T.copy({v.varname}, {k})\n"
+
+    # final_rowscales
+    # final_rowscales_init = ""
+    # for k,v in online_func.final_rowscales.items():
+    #     final_rowscales_init += f"{k} = T.alloc_fragment([{v.shape_idx}], accum_dtype)\n"
+    acco = SymbolicArray("acc_o", Var("acc_o"), shape_idx=["block_M", "dimv"])
+    for k, v in online_rowscales.items():
+        online_rowscales[k].clear_codegen()
+    acco_new, new_final_rowscales\
+        = online_func.online_fwd_epilogue(acco, online_rowscales, b, h, q_idx)
+    tl_code, input_vars_final = generate_tl_from_dag(
+        [acco_new] + list(new_final_rowscales.values()))
+    online_func_epilogue = str(tl_code)
+    input_vars.update(input_vars_final)
+    final_rowscales_output = ""
+    final_rowscales_list = ""
+    torch_alloc_final_rowscales = ""
+    for k, v in online_func.final_rowscales.items():
+        final_rowscales_output += f"g_{k}: T.Buffer([batch, heads, num_split, seq_len], accum_dtype), \n"
+        final_rowscales_list += f"g_{k}, "
+        torch_alloc_final_rowscales += f"g_{k} = torch.empty([BATCH, H, num_split, N_CTXQ], dtype=torch.float, device=q.device)\n"
+    final_rowscales_save = ""
+    for k, v in new_final_rowscales.items():
+        final_rowscales_save += f"T.copy({v.varname}, g_{k}[bid, hid, sid, mid * block_M : (mid + 1) * block_M])\n"
+
+    online_func_init = ""
+    # already in input_vars
+    # for k,v in online_rowscales.items():
+    #     online_func_init += f"{k} = T.alloc_fragment([{v.shape_idx}], accum_dtype)\n"
+    for _, input_var in input_vars.items():
+        if input_var.varname == scores_name:
+            continue
+        online_func_init += f"{input_var.varname} = T.alloc_fragment([{', '.join(input_var.shape_idx)}], accum_dtype)\n"
+
+    # acco
+    # acco = SymbolicArray("acco", Var("acco"), shape_idx=["block_M", "dimv"])
+    # acco = acco * o_scale
+    # tl_code += generate_tl(acco, varname="acco")
+
+    # tmp_solution: mask_value
+    # mask_value = "0"
+    # for used in scores.use_list:
+    #     if used.code.type == "ReduceMax":
+    #         mask_value = "-inf"
+    #         break
+    # is_inf_mask = "True" if mask_value == "-inf" else "False"
+
+    # print(tl_code)
+    # print("o_scalevar:", o_scalevar.varname)
+    # for k,v in new_online_rowscales.items():
+    #     print(f"online_rowscale['{k}'] : {v.varname}")
+    # print(input_vars)
+    # print("mask_value:", mask_value)
+    # print("online_func_epilogue:", online_func_epilogue)
+
+    # bwd
+    isused_doosum = False
+    final_rowscales_bwd = {}
+    for k, v in online_func.final_rowscales.items():
+        final_rowscales_bwd[k] = SymbolScalar(
+            f"{k}_shared", Var(f"{k}"), shape_idx=[
+                "1", "block_N"])
+    scores_2 = online_func.forward(
+        SymbolScalar(
+            "qkT",
+            Var("qkT"),
+            shape_idx=[
+                "block_M",
+                "block_N"]),
+        final_rowscales_bwd,
+        b,
+        h,
+        q_idx,
+        SymbolScalar(
+            "kv_idx",
+            Var("kv_idx")))
+
+    tl_code, input_vars_fwd = generate_tl_from_dag([scores_2])
+    online_func_fwd = str(tl_code)
+
+    dscores = online_func.backward(
+        SymbolScalar(
+            "dsT", Var("dsT"), shape_idx=[
+                "block_M", "block_N"]), SymbolScalar(
+            "qkT", Var("qkT"), shape_idx=[
+                "block_M", "block_N"]), final_rowscales_bwd, SymbolScalar(
+            "doosum_shared", Var("doosum_shared"), shape_idx=[
+                "1", "block_N"]), b, h, q_idx, SymbolScalar(
+            "kv_idx", Var("kv_idx")))
+
+    tl_code, input_vars_bwd = generate_tl_from_dag([dscores])
+    custom_bwd_body = str(tl_code)
+
+    if "doosum_shared" in input_vars_bwd:
+        isused_doosum = True
+
+    custom_bwd_inputs = f"g_doosum: T.Buffer([batch, heads, seq_len], accum_dtype), \n" if isused_doosum else ""
+    final_rowscales_shared_init = ""
+    for k, v in final_rowscales_bwd.items():
+        final_rowscales_shared_init += f"{v.varname} = T.alloc_shared([{', '.join(v.shape_idx)}], accum_dtype)\n"
+    custom_bwd_inputs_init = "doosum_shared = T.alloc_shared([1, block_N], accum_dtype)" if isused_doosum else ""
+    final_rowscales_load = ""
+    for k, v in final_rowscales_bwd.items():
+        final_rowscales_load += f"T.copy(g_{k}[bz, bx, k * block_N : (k + 1) * block_N], {v.varname})\n"
+    custom_bwd_inputs_load = "T.copy(g_doosum[bz, bx, k * block_N : (k + 1) * block_N], doosum_shared)" if isused_doosum else ""
+    final_rowscales_length = len(final_rowscales_bwd)
+
+    return lowerOnlineFuncOutput(
+        final_rowscales_list=final_rowscales_list,
+        final_rowscales_output=final_rowscales_output,
+        torch_alloc_final_rowscales=torch_alloc_final_rowscales,
+        online_rowscales_initvalue=online_rowscales_initvalue,
+        online_func_init=online_func_init,
+        online_func_inputs=online_func_inputs,
+        online_func_body=online_func_body,
+        online_func_inputs_list=online_func_inputs_list,
+        o_scale=o_scale,
+        online_func_epilogue=online_func_epilogue,
+        final_rowscales_save=final_rowscales_save,
+        online_rowscales_update=online_rowscales_update,
+        final_rowscales_init=None,
+
+        isused_doosum=isused_doosum,
+        final_rowscales_length=final_rowscales_length,
+        final_rowscales_load=final_rowscales_load,
+        online_func_fwd=online_func_fwd,
+        custom_bwd_inputs_load=custom_bwd_inputs_load,
+        custom_bwd_body=custom_bwd_body,
+        final_rowscales_shared_init=final_rowscales_shared_init,
+        custom_bwd_inputs=custom_bwd_inputs,
+        custom_bwd_inputs_init=custom_bwd_inputs_init,
+        o_scale_varname=o_scale_varname
+    )
+
+
+def lower_score_mod(score_mod, custom_fwd_inputs, lower_output: lowerOutput):
+    scores = SymbolScalar(
+        "scores",
+        Var("scores"),
+        shape_idx=[
+            "block_M",
+            "block_N"])
+    b = SymbolScalar("b", Var("b"))
+    h = SymbolScalar("h", Var("h"))
+    q_idx = SymbolScalar("q_idx", Var("q_idx"))
+    kv_idx = SymbolScalar("kv_idx", Var("kv_idx"))
+
+    scores_new = score_mod(scores, custom_fwd_inputs, b, h, q_idx, kv_idx)
+    tl_code, input_vars = generate_tl_from_dag([scores_new])
+    score_mod_body = str(tl_code)
+    score_mod_inputs = ""
+    for varname, input_var in input_vars.items():
+        score_mod_inputs += f"{input_var.varname}: T.Buffer([{', '.join(input_var.shape_idx)}], accum_dtype), \n"
+    score_mod_inputs_list = ", ".join(
+        [input_var.varname for varname, input_var in input_vars.items()])
+    # print(tl_code)
+    # print(input_vars)
+
+    # backward, block_M : k, block_N : q
+    qkT = SymbolScalar("qkT", Var("qkT"), shape_idx=["block_M", "block_N"])
+    # # modify shape idx for
+    # for k,v in custom_fwd_inputs.input_tensors.items():
+    #     custom_fwd_inputs.input_tensors[k].clear_codegen()
+    #     # TODO: not so ad hoc
+    #     if v.shape_idx == ["block_M", "block_N"]:
+    #         custom_fwd_inputs.input_tensors[k].shape_idx = ["block_N", "block_M"]
+    #     elif v.shape_idx == ["block_M"]:
+    #         custom_fwd_inputs.input_tensors[k].shape_idx = ["1", "block_N"]
+    scores_new = score_mod(qkT, custom_fwd_inputs, b, h, q_idx, kv_idx)
+    # tl_code, input_vars_fwd = generate_tl_from_dag([scores_new])
+    # score_mod_inputs_bwd_list = ", ".join([varname for varname, input_var in input_vars_fwd.items()])
+    scores_new.backward(
+        SymbolScalar(
+            "dsT",
+            Var("dsT"),
+            shape_idx=[
+                "block_M",
+                "block_N"]))
+    tl_code, input_vars_fwd = generate_tl_from_dag([scores_new])
+    score_mod_fwd_body = str(tl_code)
+    score_mod_output_var = scores_new.varname
+    score_mod_fwd_inputs = ""
+    for varname, input_var in input_vars_fwd.items():
+        score_mod_fwd_inputs += f"{input_var.varname}: T.Buffer([{', '.join(input_var.shape_idx)}], accum_dtype), \n"
+    score_mod_inputs_bwd_list = ", ".join(
+        [varname for varname, input_var in input_vars_fwd.items()])
+    tl_code, input_vars = generate_tl_from_dag([qkT.grad])
+    score_mod_backward = str(tl_code)
+    # add forward input_vars
+    for k, v in input_vars_fwd.items():
+        input_vars[k] = v
+    score_mod_bwd_inputs_list = ", ".join(
+        [input_var.varname for varname, input_var in input_vars.items()])
+    score_mod_bwd_inputs = ""
+    for varname, input_var in input_vars.items():
+        score_mod_bwd_inputs += f"{input_var.varname}: T.Buffer([{', '.join(input_var.shape_idx)}], accum_dtype), \n"
+
+    score_mod_bwd_inputs_declare = ""
+    score_mod_bwd_inputs_declare_shared = ""
+    # TODO: dtype
+    dtype = "accum_dtype"
+    for varname, input_var in input_vars.items():
+        if input_var.shape_idx == ["block_N", "block_M"]:
+            dtype = "dtype"
+            score_mod_bwd_inputs_declare_shared += f"{input_var.varname} = T.alloc_shared([{', '.join(input_var.shape_idx)}], {dtype})\n"
+        else:
+            score_mod_bwd_inputs_declare += f"{input_var.varname} = T.alloc_fragment([{', '.join(input_var.shape_idx)}], accum_dtype)\n"
+
+    return lowerScoreModOutput(
+        score_mod_inputs=score_mod_inputs,
+        score_mod_body=score_mod_body,
+        score_mod_inputs_list=score_mod_inputs_list,
+        score_mod_backward=score_mod_backward,
+        score_mod_bwd_inputs_list=score_mod_bwd_inputs_list,
+        score_mod_bwd_inputs=score_mod_bwd_inputs,
+        score_mod_inputs_bwd_list=score_mod_inputs_bwd_list,
+        score_mod_fwd_inputs=score_mod_fwd_inputs,
+        score_mod_fwd_body=score_mod_fwd_body,
+        score_mod_output_var=score_mod_output_var,
+        score_mod_bwd_inputs_declare=score_mod_bwd_inputs_declare,
+        score_mod_bwd_inputs_declare_shared=score_mod_bwd_inputs_declare_shared
+    )
+
+
+def lower_tl(score_mod, block_mask, online_func,
+             custom_fwd_inputs,
+             Batch, head, seqlenkv,
+             dimqk, dimv, tl_dtype, mask_value, tuned_config=None):
+
+    lower_output = lowerOutput()
+    lower_output.tl_dtype = tl_dtype
+    # TODO: mask_value: 0 or -inf
+    lower_output.is_inf_mask = "True" if block_mask is not None and mask_value == "-inf" else "False"
+
+    # tune
+    if tuned_config is None:
+        tune_output = TunnerOutput()
+    else:
+        tune_output = TunnerOutput(**tuned_config)
+    scores_name = "scores"
+    # TODO
+    if dimv > 256:
+        tune_output.block_M = "64"
+        tune_output.block_N = "64"
+        tune_output.stages = "1"
+        tune_output.shared_fuse = "True"
+    # TODO: ugly
+    if tune_output.shared_fuse == "True":
+        scores_name = "scores_1"
+
+    custom_fwd_inputs_load_shared_bwd = ""
+    # for k,v in custom_fwd_inputs.input_tensors.items():
+    #     # modify shape
+    #     shape_idx_copy = [(shape_idx_map_bwd[shape] if shape in shape_idx_map_bwd.keys() else ":") for shape in v.shape_idx]
+    #     shape_idx_block = [(shape_idx_onchip_map_bwd[shape] if shape in shape_idx_onchip_map_bwd.keys() else shape) for shape in v.shape_idx]
+    #     # remove "" in list
+    #     shape_idx_block = [shape for shape in shape_idx_block if shape != ""] # TODO:bug[block_M] -> [1,block_M]
+    #     custom_input_dtype = "accum_dtype"
+    #     # load
+    #     # tl copy bug when "1"
+    #     if shape_idx_block == ["1"]:
+    #         pass
+    #         # custom_fwd_inputs_load_prolog += f"{k}[0] = g_{k}[{', '.join(shape_idx_copy)}]\n"
+    #     elif not (RECURRENT_DIM in shape_idx_block):
+    #         pass
+    #         # custom_fwd_inputs_load_prolog += f"T.copy(g_{k}[{', '.join(shape_idx_copy)}], {k})\n"
+    #     elif len(shape_idx_block) > 1 and shape_idx_block[1] != "1": # [block_N, block_M]
+    #         custom_input_dtype = "dtype"
+    #         custom_fwd_inputs_init += f"{k}_shared = T.alloc_shared([{', '.join(shape_idx_block)}], {custom_input_dtype})\n"
+    #         custom_fwd_inputs_load_shared_bwd += f"T.copy(g_{k}[{', '.join(shape_idx_copy)}], {k}_shared)\n"
+    #         custom_fwd_inputs_load_s2r += f"T.copy({k}_shared, {k})\n"
+    #     else:# [block_N, 1]
+    #         custom_fwd_inputs_load_shared_bwd += f"T.copy(g_{k}[{', '.join(shape_idx_copy)}], {k})\n"
+    #     # TODO: dtype of custom_fwd_inputs
+    #     custom_fwd_inputs_init += f"{k} = T.alloc_fragment([{', '.join(shape_idx_block)}], {custom_input_dtype})\n"
+    #     custom_fwd_inputs_str += f"g_{k}: T.Buffer([{', '.join(v.shape_idx)}], {custom_input_dtype}), \n"
+    #     custom_fwd_inputs.input_tensors[k].shape_idx = shape_idx_block
+
+    custom_fwd_inputs_str = ""
+    custom_fwd_inputs_list = ""
+    # for k,v in custom_fwd_inputs.input_tensors.items():
+    #     custom_fwd_inputs_str += f"g_{k}: T.Buffer([{', '.join(v.shape_idx)}], accum_dtype), \n"
+    custom_fwd_inputs_init = ""
+    custom_fwd_inputs_load_prolog = ""
+    custom_fwd_inputs_load_shared = ""
+    custom_fwd_inputs_load_s2r = ""
+    for k, v in custom_fwd_inputs.input_tensors.items():
+        # modify shape
+        shape_idx_copy = [(shape_idx_map[shape] if shape in shape_idx_map.keys(
+        ) else ":") for shape in v.shape_idx]
+        shape_idx_block = [(shape_idx_onchip_map[shape] if shape in shape_idx_onchip_map.keys(
+        ) else shape) for shape in v.shape_idx]
+        # remove "" in list
+        # TODO:bug[block_N] -> [1,block_N]
+        shape_idx_block = [shape for shape in shape_idx_block if shape != ""]
+        custom_input_dtype = "accum_dtype"
+        # load
+        # tl copy bug when "1"
+        if shape_idx_block == []:
+            # shape_idx_copy = [idx_copy if idx_copy != ":" else "0" for idx_copy in shape_idx_copy]
+            shape_idx_block = ["1"]
+            custom_fwd_inputs_load_prolog += f"{k}[0] = g_{k}[{', '.join(shape_idx_copy)}]\n"
+        elif not (RECURRENT_DIM in shape_idx_block):
+            custom_fwd_inputs_load_prolog += f"T.copy(g_{k}[{', '.join(shape_idx_copy)}], {k})\n"
+        elif len(shape_idx_block) > 1 and shape_idx_block[0] != "1":
+            custom_input_dtype = "dtype"
+            custom_fwd_inputs_init += f"{k}_shared = T.alloc_shared([{', '.join(shape_idx_block)}], {custom_input_dtype})\n"
+            custom_fwd_inputs_load_shared += f"T.copy(g_{k}[{', '.join(shape_idx_copy)}], {k}_shared)\n"
+            custom_fwd_inputs_load_s2r += f"T.copy({k}_shared, {k})\n"
+            lower_output.swizzle_shared += f"{k}_shared: tl.layout.make_swizzled_layout({k}_shared), \n"
+        else:
+            custom_fwd_inputs_load_shared += f"T.copy(g_{k}[{', '.join(shape_idx_copy)}], {k})\n"
+        # TODO: dtype of custom_fwd_inputs
+        custom_fwd_inputs_init += f"{k} = T.alloc_fragment([{', '.join(shape_idx_block)}], {custom_input_dtype})\n"
+        custom_fwd_inputs_str += f"g_{k}: T.Buffer([{', '.join(v.shape_idx)}], {custom_input_dtype}), \n"
+        custom_fwd_inputs_list += f"g_{k}, "
+        custom_fwd_inputs.input_tensors[k].shape_idx = shape_idx_block
+
+    lower_score_mod_output = lower_score_mod(
+        score_mod, custom_fwd_inputs, lower_output)
+    lower_online_func_output = lower_online_func(
+        online_func, lower_output, scores_name)
+    output_idx_list = [i for i in range(4 +
+                                        len(custom_fwd_inputs.input_tensors) +
+                                        len(online_func.final_rowscales), 4 +
+                                        1 +
+                                        len(custom_fwd_inputs.input_tensors) +
+                                        len(online_func.final_rowscales))]
+
+    # TODO: custom_fwd_inputs grad
+    bwd_output_idx_list = [i for i in range(4 +
+                                            len(custom_fwd_inputs.input_tensors) +
+                                            len(online_func.final_rowscales) +
+                                            int(lower_online_func_output.isused_doosum), 4 +
+                                            len(custom_fwd_inputs.input_tensors) +
+                                            len(online_func.final_rowscales) +
+                                            int(lower_online_func_output.isused_doosum) +
+                                            3)]
+    if block_mask is not None:
+        block_M = int(tune_output.block_M)
+        block_N = int(tune_output.block_N)
+        block_mask = create_block_mask(block_mask, Batch, head, 1, seqlenkv, "cuda" if torch.cuda.is_available() else "cpu", block_M, block_N)
+    else:
+        block_mask = torch.ones((Batch, head, 1, seqlenkv), dtype=torch.uint8, device="cuda" if torch.cuda.is_available() else "cpu")
+        
+    return TlAttnTemplate(
+        TEMPLATE_PATH,
+        custom_fwd_inputs=custom_fwd_inputs_str,
+        custom_fwd_inputs_list=custom_fwd_inputs_list,
+        custom_fwd_inputs_init=custom_fwd_inputs_init,
+        custom_fwd_inputs_load_prolog=custom_fwd_inputs_load_prolog,
+        custom_fwd_inputs_load_s2r=custom_fwd_inputs_load_s2r,
+        custom_fwd_inputs_load_shared=custom_fwd_inputs_load_shared,
+        custom_fwd_inputs_load_shared_bwd=custom_fwd_inputs_load_shared_bwd,
+        **lower_online_func_output.__dict__,
+        **lower_score_mod_output.__dict__,
+
+        **lower_output.__dict__,
+        **tune_output.__dict__,
+
+        output_idx_list=str(output_idx_list),
+        bwd_output_idx_list=str(bwd_output_idx_list)
+    )(), block_mask
+
+
+if __name__ == "__main__":
+    from mha import OnlineSoftmax
+    lower_online_func(OnlineSoftmax())
+    print("---------------------")
+    from mha import score_mod
+    custom_fwd_inputs = CustomIO({
+        "softmax_scale": (1,)
+    })
+    lower_score_mod(score_mod, custom_fwd_inputs)
+
+    aaa = SymbolScalar("aaa", Var("aaa"))
+    b = 5.4
+    a = 3
+    aaa = aaa * (b / a)
+    print(aaa.code)
+    print(generate_tl_from_dag([aaa]))
+
+    print("lower_tl:")
+    tl_code = lower_tl(score_mod, None, OnlineSoftmax(), custom_fwd_inputs)
+    with open("generated_tl_code.py", "w") as f:
+        f.write(tl_code)

--- a/attention_engine/core/tl_template/attn/attn_gqa_inference_tl.py
+++ b/attention_engine/core/tl_template/attn/attn_gqa_inference_tl.py
@@ -1,0 +1,322 @@
+import torch
+import torch.nn.functional as F
+import tilelang
+from tilelang.autotuner import *
+import tilelang.language as T
+import itertools
+
+# TL_GLOBAL_FUNC = """
+def fast_tanh(A, B):
+    return T.call_extern("handle", "fasttanh", T.address_of(A), T.address_of(B))
+
+def make_dq_layout(dQ):
+    # atomicAdd can not be vectorized, so we need to reorder dq to match the 8x8 gemm fragment
+    return T.Layout(
+        dQ.shape, lambda b, l, h, d: [b, l // 8, h, d // 8, (d % 2), 4 * (l % 8) + (d % 8) // 2]
+    )
+
+def get_configs():
+    block_N = [64, 128]
+    block_H = [64]
+    num_split = [2, 4, 8]
+    num_stages = [1, 2, 3]
+    threads = [128]
+    _configs = list(itertools.product(block_N, block_H, num_split, num_stages, threads))
+
+    configs = [{
+        'block_N': c[0],
+        'block_H': c[1],
+        'num_split': c[2],
+        'num_stages': c[3],
+        'threads': c[4]
+    } for c in _configs]
+    return configs
+
+
+def kernel(batch, heads, groups, seqlen_kv, dim, dimv, tune=False):
+    scale = (1.0 / dim)**0.5 * 1.44269504  # log2(e)
+    shape_q = [batch, heads, dim]
+    shape_k = [batch, seqlen_kv, groups, dim]
+    shape_v = [batch, seqlen_kv, groups, dimv]
+    shape_o = [batch, heads, dimv]
+    dtype = "{{tl_dtype}}" # "float16"
+    accum_dtype = "float"
+    kv_group_num = heads // groups
+
+    def kernel_func(block_N, block_H, num_split, num_stages, threads):
+        part_shape = [batch, heads, num_split, dimv]
+        valid_block_H = min(block_H, kv_group_num)
+        
+         # TL_MAIN = """
+        @T.macro
+        def score_mod(
+            # scores: T.Buffer([block_M, block_N], accum_dtype),
+            {{score_mod_inputs | indent(12)}}
+            ):
+            {{score_mod_body | indent(12)}}
+            pass
+        
+        @T.macro
+        def online_func(
+            # scores: T.Buffer([block_M, block_N], accum_dtype),
+            {{online_func_inputs | indent(12)}}
+        ):
+            {{online_func_body | indent(12)}}
+            pass
+
+        @T.macro
+        def flash_attn(
+                Q: T.Buffer(shape_q, dtype),
+                K: T.Buffer(shape_k, dtype),
+                V: T.Buffer(shape_v, dtype),
+                {{custom_fwd_inputs | indent(8)}}
+                
+                mask: T.Buffer([batch, groups, 1, seqlen_kv], "uint8"),
+                Output: T.Buffer([batch, heads, dimv], dtype),
+                {{final_rowscales_output | indent(8)}}
+        ):
+            with T.Kernel(
+                    batch, heads // valid_block_H, num_split, threads=threads) as (bx, by, bz):
+                Q_shared = T.alloc_shared([block_H, dim], dtype)
+                K_shared = T.alloc_shared([block_N, dim], dtype)
+                V_shared = T.alloc_shared([block_N, dimv], dtype)
+                O_shared = T.alloc_shared([valid_block_H, dimv], dtype)
+                acc_s = T.alloc_fragment([block_H, block_N], accum_dtype)
+                acc_s_cast = T.alloc_fragment([block_H, block_N], dtype)
+                mask_local = T.alloc_fragment([block_N], "uint8")
+                acc_o = T.alloc_fragment([block_H, dimv], accum_dtype)
+                scores_max = T.alloc_fragment([block_H], accum_dtype)
+                scores_max_prev = T.alloc_fragment([block_H], accum_dtype)
+                scores_scale = T.alloc_fragment([block_H], accum_dtype)
+                scores_sum = T.alloc_fragment([block_H], accum_dtype)
+                logsum = T.alloc_fragment([block_H], accum_dtype)
+
+                bid = bx
+                hid = by
+                cur_kv_head = hid // (kv_group_num // valid_block_H)
+
+                T.copy(Q[bid, hid * valid_block_H:hid * valid_block_H + block_H, :], Q_shared)
+                T.fill(acc_o, 0)
+                T.fill(logsum, 0)
+                T.fill(scores_max, -T.infinity(accum_dtype))
+
+                loop_range = T.ceildiv((seqlen_kv // num_split), block_N)
+                for k in T.Pipelined(loop_range, num_stages=num_stages):
+                    T.copy(K[bid, k * block_N:(k + 1) * block_N, cur_kv_head, :], K_shared)
+                    T.copy(mask[bid, cur_kv_head, 0, k * block_N:(k + 1) * block_N], mask_local)
+                    T.clear(acc_s)
+                    T.gemm(
+                        Q_shared,
+                        K_shared,
+                        acc_s,
+                        transpose_B=True,
+                        policy=T.GemmWarpPolicy.FullRow)
+                    for i, j in T.Parallel(block_H, block_N):
+                        acc_s[i, j] = T.if_then_else(mask_local[j] != 0, acc_s[i, j],
+                                                     -T.infinity(accum_dtype))
+                    T.copy(scores_max, scores_max_prev)
+                    T.fill(scores_max, -T.infinity(accum_dtype))
+                    T.reduce_max(acc_s, scores_max, dim=1, clear=False)
+                    for i in T.Parallel(block_H):
+                        scores_scale[i] = T.exp2(scores_max_prev[i] * scale - scores_max[i] * scale)
+                    for i, j in T.Parallel(block_H, block_N):
+                        acc_s[i, j] = T.exp2(acc_s[i, j] * scale - scores_max[i] * scale)
+                    T.reduce_sum(acc_s, scores_sum, dim=1)
+                    for i in T.Parallel(block_H):
+                        logsum[i] = logsum[i] * scores_scale[i] + scores_sum[i]
+                    T.copy(acc_s, acc_s_cast)
+                    for i, j in T.Parallel(block_H, dim):
+                        acc_o[i, j] *= scores_scale[i]
+                    T.copy(V[bid, k * block_N:(k + 1) * block_N, cur_kv_head, :], V_shared)
+                    T.gemm(acc_s_cast, V_shared, acc_o, policy=T.GemmWarpPolicy.FullRow)
+                for i, j in T.Parallel(block_H, dim):
+                    acc_o[i, j] /= logsum[i]
+                for i in T.Parallel(block_H):
+                    logsum[i] = T.log2(logsum[i]) + scores_max[i] * scale
+                T.copy(acc_o[:valid_block_H, :], O_shared)
+                T.copy(O_shared, Output[bid, hid * valid_block_H:(hid + 1) * valid_block_H, :])
+
+        @T.macro
+        def flash_attn_split(
+                Q: T.Buffer(shape_q, dtype),
+                K: T.Buffer(shape_k, dtype),
+                V: T.Buffer(shape_v, dtype),
+                mask: T.Buffer([batch, groups, 1, seqlen_kv], "uint8"),
+                glse: T.Buffer([batch, heads, num_split], dtype),
+                Output_partial: T.Buffer(part_shape, dtype),
+        ):
+            with T.Kernel(
+                    batch, heads // valid_block_H, num_split, threads=threads) as (bx, by, bz):
+                Q_shared = T.alloc_shared([block_H, dim], dtype)
+                K_shared = T.alloc_shared([block_N, dim], dtype)
+                V_shared = T.alloc_shared([block_N, dim], dtype)
+                O_shared = T.alloc_shared([valid_block_H, dim], dtype)
+                acc_s = T.alloc_fragment([block_H, block_N], accum_dtype)
+                acc_s_cast = T.alloc_fragment([block_H, block_N], dtype)
+                mask_local = T.alloc_fragment([block_N], "uint8")
+                acc_o = T.alloc_fragment([block_H, dim], accum_dtype)
+                scores_max = T.alloc_fragment([block_H], accum_dtype)
+                scores_max_prev = T.alloc_fragment([block_H], accum_dtype)
+                scores_scale = T.alloc_fragment([block_H], accum_dtype)
+                scores_sum = T.alloc_fragment([block_H], accum_dtype)
+                logsum = T.alloc_fragment([block_H], accum_dtype)
+
+                bid = bx
+                hid = by
+                sid = bz
+                cur_kv_head = hid // (kv_group_num // valid_block_H)
+
+                T.copy(Q[bid, hid * valid_block_H:hid * valid_block_H + block_H, :], Q_shared)
+                T.fill(acc_o, 0)
+                T.fill(logsum, 0)
+                T.fill(scores_max, -T.infinity(accum_dtype))
+
+                loop_range = T.ceildiv((seqlen_kv // num_split), block_N)
+                for k in T.Pipelined(loop_range, num_stages=num_stages):
+                    T.copy(
+                        K[bid, (seqlen_kv // num_split) * sid +
+                          k * block_N:(seqlen_kv // num_split) * sid + (k + 1) * block_N,
+                          cur_kv_head, :], K_shared)
+                    T.copy(
+                        mask[bid, cur_kv_head, 1, (seqlen_kv // num_split) * sid +
+                             k * block_N:(seqlen_kv // num_split) * sid + (k + 1) * block_N], mask_local)
+                    T.clear(acc_s)
+                    T.gemm(
+                        Q_shared,
+                        K_shared,
+                        acc_s,
+                        transpose_B=True,
+                        policy=T.GemmWarpPolicy.FullRow)
+                    for i, j in T.Parallel(block_H, block_N):
+                        acc_s[i, j] = T.if_then_else(mask_local[j] != 0, acc_s[i, j],
+                                                     -T.infinity(accum_dtype))
+                    T.copy(scores_max, scores_max_prev)
+                    T.fill(scores_max, -T.infinity(accum_dtype))
+                    T.reduce_max(acc_s, scores_max, dim=1, clear=False)
+                    for i in T.Parallel(block_H):
+                        scores_scale[i] = T.exp2(scores_max_prev[i] * scale - scores_max[i] * scale)
+                    for i, j in T.Parallel(block_H, block_N):
+                        acc_s[i, j] = T.exp2(acc_s[i, j] * scale - scores_max[i] * scale)
+                    T.reduce_sum(acc_s, scores_sum, dim=1)
+                    for i in T.Parallel(block_H):
+                        logsum[i] = logsum[i] * scores_scale[i] + scores_sum[i]
+                    T.copy(acc_s, acc_s_cast)
+                    for i, j in T.Parallel(block_H, dim):
+                        acc_o[i, j] *= scores_scale[i]
+                    T.copy(
+                        V[bid, (seqlen_kv // num_split) * sid +
+                          k * block_N:(seqlen_kv // num_split) * sid + (k + 1) * block_N,
+                          cur_kv_head, :], V_shared)
+                    T.gemm(acc_s_cast, V_shared, acc_o, policy=T.GemmWarpPolicy.FullRow)
+                for i, j in T.Parallel(block_H, dim):
+                    acc_o[i, j] /= logsum[i]
+                for i in T.Parallel(block_H):
+                    logsum[i] = T.log2(logsum[i]) + scores_max[i] * scale
+
+                T.copy(logsum[:valid_block_H],
+                       glse[bid, hid * valid_block_H:(hid + 1) * valid_block_H, sid])
+                T.copy(acc_o[:valid_block_H, :], O_shared)
+                T.copy(O_shared, Output_partial[bid, hid * valid_block_H:(hid + 1) * valid_block_H,
+                                                sid, :])
+
+        @T.macro
+        def combine(
+                glse: T.Buffer([batch, heads, num_split], dtype),
+                Output_partial: T.Buffer(part_shape, dtype),
+                Output: T.Buffer(shape_o, dtype),
+        ):
+            with T.Kernel(heads, batch, threads=128) as (by, bz):
+                po_local = T.alloc_fragment([dim], dtype)
+                o_accum_local = T.alloc_fragment([dim], accum_dtype)
+                lse_local = T.alloc_fragment([num_split, 128], dtype)
+                lse_local_split = T.alloc_local([1], accum_dtype)
+                lse_logsum_local = T.alloc_local([1], accum_dtype)
+                lse_max_local = T.alloc_fragment([128], accum_dtype)
+                scale_local = T.alloc_local([1], accum_dtype)
+
+                T.annotate_layout({
+                    lse_logsum_local:
+                        T.Fragment(lse_logsum_local.shape, forward_thread_fn=lambda i: i),
+                    lse_max_local:
+                        T.Fragment(lse_max_local.shape, forward_thread_fn=lambda i: i),
+                    lse_local:
+                        T.Fragment(lse_local.shape, forward_thread_fn=lambda i, j: j),
+                })
+
+                T.clear(lse_logsum_local)
+                T.clear(o_accum_local)
+                for k in T.Parallel(num_split):
+                    lse_local[k, 0] = glse[bz, by, k]
+                T.reduce_max(lse_local, lse_max_local, dim=0, clear=True)
+                for k in T.Pipelined(num_split, num_stages=1):
+                    lse_local_split[0] = glse[bz, by, k]
+                    lse_logsum_local[0] += T.exp2(lse_local_split[0] - lse_max_local[0])
+                lse_logsum_local[0] = T.log2(lse_logsum_local[0]) + lse_max_local[0]
+                for k in T.serial(num_split):
+                    for i in T.Parallel(dim):
+                        po_local[i] = Output_partial[bz, by, k, i]
+                    lse_local_split[0] = glse[bz, by, k]
+                    scale_local[0] = T.exp2(lse_local_split[0] - lse_logsum_local[0])
+                    for i in T.Parallel(dim):
+                        o_accum_local[i] += po_local[i] * scale_local[0]
+                for i in T.Parallel(dim):
+                    Output[bz, by, i] = o_accum_local[i]
+
+        @T.prim_func
+        def main_split(
+                Q: T.Buffer(shape_q, dtype),
+                K: T.Buffer(shape_k, dtype),
+                V: T.Buffer(shape_v, dtype),
+                mask: T.Buffer([batch, groups, 1, seqlen_kv], "uint8"),
+                glse: T.Buffer([batch, heads, num_split], dtype),
+                Output_partial: T.Buffer(part_shape, dtype),
+                Output: T.Buffer(shape_o, dtype),
+        ):
+            flash_attn_split(Q, K, V, mask, glse, Output_partial)
+            combine(glse, Output_partial, Output)
+
+        @T.prim_func
+        def main_no_split(
+                Q: T.Buffer(shape_q, dtype),
+                K: T.Buffer(shape_k, dtype),
+                V: T.Buffer(shape_v, dtype),
+                mask: T.Buffer([batch, groups, 1, seqlen_kv], "uint8"),
+                glse: T.Buffer([batch, heads, num_split], dtype),
+                Output_partial: T.Buffer(part_shape, dtype),
+                Output: T.Buffer(shape_o, dtype),
+        ):
+            flash_attn(Q, K, V, mask, Output)
+
+        if num_split > 1:
+            return main_split
+        else:
+            return main_no_split
+
+    if tune:
+
+        @autotune(
+            configs=get_configs(),
+            keys=["block_N", "block_H", "num_split", "num_stages", "threads"],
+            warmup=10,
+            rep=10)
+        @jit(
+            out_idx=[6],
+            supply_type=tilelang.TensorSupplyType.Auto,
+            ref_prog=ref_program,
+            max_mismatched_ratio=0.05,
+            profiler="auto")
+        def kernel(block_N=None, block_H=None, num_split=None, num_stages=None, threads=None):
+            return kernel_func(block_N, block_H, num_split, num_stages, threads)
+
+        return kernel()
+    else:
+
+        def kernel(block_N, block_H, num_split, num_stages, threads):
+            return kernel_func(block_N, block_H, num_split, num_stages, threads)
+
+        return kernel
+
+program = kernel(
+                block_N={{block_N}}, block_H={{block_M}}, num_split=8, num_stages=2, threads=128)
+torch_kernel = tilelang.compile(program, out_idx=[6])
+attention = torch_kernel

--- a/attention_engine/core/tl_template/attn/blockattn_tl.py
+++ b/attention_engine/core/tl_template/attn/blockattn_tl.py
@@ -15,6 +15,7 @@ def make_dq_layout(dQ):
 
 # TL_KERNEL = """
 def kernel(batch, heads, seq_len, dim, dimv, 
+           downsample_len,
         block_M = None, block_N = None, num_stages = None, thread_num = None,
         shared_fuse = None):
     # scale = (1.0 / dim) ** 0.5 * 1.44269504  # log2(e) # 0.69314718  loge(2)
@@ -22,12 +23,15 @@ def kernel(batch, heads, seq_len, dim, dimv,
     shape_v = [batch, seq_len, heads, dimv]
     # TODO: seqlenkv
     seq_len_kv = seq_len
+    block_mask_shape = [batch, heads, downsample_len, downsample_len]
     dtype = "{{tl_dtype}}" # "float16"
     accum_dtype = "float"
+    block_mask_dtype = "int8"
     
     # TODO: mask
     is_casual = {{is_casual}} # True
     # shared_fuse = True
+    assert(downsample_len == seq_len_kv // block_N)
 
 # TL_MAIN = """
     @T.macro
@@ -54,6 +58,7 @@ def kernel(batch, heads, seq_len, dim, dimv,
         V: T.Buffer(shape_v, dtype), # type: ignore
         {{custom_fwd_inputs | indent(8)}}
 
+        BlockSparseMask: T.Buffer(block_mask_shape, block_mask_dtype), # type: ignore
         Output: T.Buffer(shape_v, dtype), # type: ignore
         {{final_rowscales_output | indent(8)}}
     ):
@@ -72,6 +77,8 @@ def kernel(batch, heads, seq_len, dim, dimv,
             {{custom_fwd_inputs_init | indent(12)}}
             {{online_func_init | indent(12)}}
             {{final_rowscales_init | indent(12)}}
+            
+            block_mask = T.alloc_local([downsample_len], block_mask_dtype)
 
             T.annotate_layout({
                 Q_shared: tl.layout.make_swizzled_layout(Q_shared),
@@ -85,56 +92,60 @@ def kernel(batch, heads, seq_len, dim, dimv,
 
             {{online_rowscales_initvalue | indent(12)}}
 
+            for vj in T.serial(downsample_len):
+                    block_mask[vj] = BlockSparseMask[bz, by, bx, vj]
+
             # TODO: mask
             loop_range = (
                 T.ceildiv((bx + 1) * block_M, block_N) if is_casual else T.ceildiv(seq_len, block_N)
             )
 
             for k in T.Pipelined(loop_range, num_stages=num_stages):
-                T.copy(K[bz, k * block_N : (k + 1) * block_N, by, :], K_shared)
+                if block_mask[k] != 0:
+                    T.copy(K[bz, k * block_N : (k + 1) * block_N, by, :], K_shared)
 
-                # TODO: copy custom_fwd_input_tensor in score_mod&online_func
-                {{custom_fwd_inputs_load_shared | indent(16)}}
+                    # TODO: copy custom_fwd_input_tensor in score_mod&online_func
+                    {{custom_fwd_inputs_load_shared | indent(20)}}
 
-                # TODO: naive solution: if reduce_max, -T.inf; if reduce_sum, 0
-                if is_casual and {{is_inf_mask}}:
-                    for i, j in T.Parallel(block_M, block_N):
-                        scores[i, j] = T.if_then_else(
-                            bx * block_M + i >= k * block_N + j, 0, -T.infinity(scores.dtype)
-                        )
-                else:
-                    T.clear(scores)
-                
-                T.gemm(Q_shared, K_shared, scores, transpose_B=True, policy= (T.GemmWarpPolicy.FullRow if (not shared_fuse) else T.GemmWarpPolicy.FullCol))
-                T.copy(V[bz, k * block_N : (k + 1) * block_N, by, :], V_shared)
+                    # TODO: naive solution: if reduce_max, -T.inf; if reduce_sum, 0
+                    if is_casual and {{is_inf_mask}}:
+                        for i, j in T.Parallel(block_M, block_N):
+                            scores[i, j] = T.if_then_else(
+                                bx * block_M + i >= k * block_N + j, 0, -T.infinity(scores.dtype)
+                            )
+                    else:
+                        T.clear(scores)
                     
-                {{custom_fwd_inputs_load_s2r | indent(16)}}
-                # call score_mod
-                score_mod({{score_mod_inputs_list}}) # scores
+                    T.gemm(Q_shared, K_shared, scores, transpose_B=True, policy= (T.GemmWarpPolicy.FullRow if (not shared_fuse) else T.GemmWarpPolicy.FullCol))
+                    T.copy(V[bz, k * block_N : (k + 1) * block_N, by, :], V_shared)
+                        
+                    {{custom_fwd_inputs_load_s2r | indent(20)}}
+                    # call score_mod
+                    score_mod({{score_mod_inputs_list}}) # scores
+                        
+                    # call online_func
+                    if shared_fuse:
+                        T.copy(scores, scores_shared)
+                        T.copy(scores_shared, scores_1)
+                        online_func({{online_func_inputs_list}})
+                        T.copy(scores_1, acc_s_cast_1)
+
+                    else:
+                        online_func({{online_func_inputs_list}}) # scores
+                        T.copy(scores, acc_s_cast)
+
+                    # for i, j in T.Parallel(block_M, dimv):
+                    #     acc_o[i, j] *= o_scale[i]
+                    {{o_scale | indent(20)}}
                     
-                # call online_func
-                if shared_fuse:
-                    T.copy(scores, scores_shared)
-                    T.copy(scores_shared, scores_1)
-                    online_func({{online_func_inputs_list}})
-                    T.copy(scores_1, acc_s_cast_1)
+                    # update online_rowscales
+                    {{online_rowscales_update | indent(20)}}
 
-                else:
-                    online_func({{online_func_inputs_list}}) # scores
-                    T.copy(scores, acc_s_cast)
-
-                # for i, j in T.Parallel(block_M, dimv):
-                #     acc_o[i, j] *= o_scale[i]
-                {{o_scale | indent(16)}}
+                    if shared_fuse:
+                        T.gemm(acc_s_cast_1, V_shared, acc_o, policy=(T.GemmWarpPolicy.FullCol))
+                    else:
+                        T.gemm(acc_s_cast, V_shared, acc_o, policy=T.GemmWarpPolicy.FullRow)
                 
-                # update online_rowscales
-                {{online_rowscales_update | indent(16)}}
-
-                if shared_fuse:
-                    T.gemm(acc_s_cast_1, V_shared, acc_o, policy=(T.GemmWarpPolicy.FullCol))
-                else:
-                    T.gemm(acc_s_cast, V_shared, acc_o, policy=T.GemmWarpPolicy.FullRow)
-            
             # online_fwd_epilogue
             {{online_func_epilogue | indent(12)}}
 
@@ -366,6 +377,7 @@ def flashattn_bwd_postprocess(batch, heads, seq_len, dim, dimv):
 class _attention(torch.autograd.Function):
     @staticmethod
     def forward(ctx, q, k, v, *custom_fwd_inputs):
+        custom_fwd_inputs, block_sparse_mask = custom_fwd_inputs[:-1], custom_fwd_inputs[-1]
         BATCH, N_CTX, H, D_HEAD = q.shape
         D_HEADV = v.shape[-1]
         block_M = {{block_M}} # 128
@@ -376,10 +388,10 @@ class _attention(torch.autograd.Function):
         output_idx_list = {{output_idx_list}}
         mod = tl.profiler.cached(kernel, output_idx_list, BATCH, H, N_CTX, D_HEAD, D_HEADV, block_M, block_N, stages, thread_num, shared_fuse)
         if len(output_idx_list) == 1:
-            o = mod(q, k, v, *custom_fwd_inputs)
+            o = mod(q, k, v, *custom_fwd_inputs, block_sparse_mask)
             final_scale = []
         else:
-            o, *final_scale = mod(q, k, v, *custom_fwd_inputs)
+            o, *final_scale = mod(q, k, v, *custom_fwd_inputs, block_sparse_mask)
         ctx.save_for_backward(q, k, v, o, *custom_fwd_inputs, *final_scale)
         return o
     

--- a/attention_engine/tests/test_blockmask.py
+++ b/attention_engine/tests/test_blockmask.py
@@ -1,0 +1,27 @@
+from core.core import create_block_mask, is_causal_mask, is_less_causal_mask
+# mask on attention score
+def causal_mask(b, h, q_idx, kv_idx):
+    return q_idx >= kv_idx
+
+def causal_mask_1(b, h, q_idx, kv_idx):
+    return q_idx+1 >= kv_idx
+
+def causal_mask_2(b, h, q_idx, kv_idx):
+    return q_idx-128 >= kv_idx
+
+B, H, S = 2, 4, 512
+
+Q_BLOCK_SIZE = 128
+K_BLOCK_SIZE = 64
+def test_mask(mask_mod):
+    mask_tensor = create_block_mask(mask_mod, B, H, S, S, "cpu", Q_BLOCK_SIZE, K_BLOCK_SIZE)
+    print(mask_tensor.shape)
+    print(mask_tensor)
+
+    print(is_causal_mask(mask_tensor, Q_BLOCK_SIZE, K_BLOCK_SIZE))
+    print(is_less_causal_mask(mask_tensor, Q_BLOCK_SIZE, K_BLOCK_SIZE))
+
+test_mask(causal_mask)
+test_mask(causal_mask_1)
+test_mask(causal_mask_2)
+

--- a/attn_script/blocksparseattn.py
+++ b/attn_script/blocksparseattn.py
@@ -1,0 +1,135 @@
+from attn_engine import AttentionEngine
+import torch
+import math
+from attn_engine import OnlineFunc
+from core.core import CustomIO
+from core.core import create_block_mask
+from core.core import SymbolicArray, SymbolScalar, SymbolicTensor
+from core.core import Var
+from core.utils import meta_tensor
+
+"""
+Example of causal attention with online softmax
+"""
+
+
+
+BLOCK = 128
+# mask on attention score
+def block_sparse_mask(b, h, q_idx, kv_idx):
+    return torch.logical_and(q_idx >= kv_idx, q_idx//BLOCK < kv_idx//BLOCK + 2)
+def causal_mask(b, h, q_idx, kv_idx):
+    return q_idx >= kv_idx
+D = 128
+softmax_scale = 1/D ** 0.5
+# elementwise on attention scores
+def score_mod(score, custom_fwd_inputs, b, h, q_idx, kv_idx):
+    # softmax_scale = custom_fwd_inputs.input_tensors["softmax_scale"]
+    return score * softmax_scale
+
+class OnlineSoftmax(OnlineFunc):
+    def __init__(self):
+        """
+        define online_rowscales and final_rowscales
+        """
+        online_rowscales = {
+            "m": SymbolScalar("m", Var("-inf")), # -inf 
+            "r": SymbolScalar("r", Var("0.0")),
+        }
+        final_rowscales = {
+            "lse": SymbolScalar("lse", Var("0.0")), # not used in codegen
+        }
+        external_fwd_inputs = CustomIO()
+        # external_bwd_inputs = CustomIO({
+        #     "dppsum": (B,H,S),
+        # })
+        super().__init__(online_rowscales, final_rowscales,
+                    external_fwd_inputs) # , external_bwd_inputs)
+    
+
+    @staticmethod
+    def online_fwd(scores, online_rowscales, b, h, q_idx):
+
+        m , r = online_rowscales["m"], online_rowscales["r"]
+        m_new = m.max(scores.get_reduce("max"))
+        scale_tmp = (m - m_new).exp()
+        r = r * scale_tmp
+        
+        scores = (scores - m_new).exp()
+        r = r + scores.get_reduce("sum")
+
+        new_online_rowscales = {
+            "m": m_new,
+            "r": r,
+        }
+        o_scale = scale_tmp
+        return scores, new_online_rowscales, o_scale
+
+    @staticmethod
+    def online_fwd_epilogue(o, online_rowscales, b, h, q_idx):
+        o_new = o / online_rowscales["r"]
+        lse = (online_rowscales["r"]).log() + online_rowscales["m"]
+        final_rowscales = {
+            "lse": lse,
+        }
+        return o_new, final_rowscales
+
+    @staticmethod
+    def forward(scores, final_rowscales, b, h, q_idx, kv_idx):
+        lse = final_rowscales["lse"]
+        scores_new = (scores-lse).exp()
+        return scores_new
+    
+    @staticmethod
+    def backward(dp, scores, final_rowscales, doosum_rowscales, b, h, q_idx, kv_idx):
+        dppsum = doosum_rowscales # external_bwd_tensor.input_tensors["dppsum"]
+        dscores = (dp - dppsum)*scores # TODO: bug if swap
+        return dscores
+
+if __name__ == "__main__":
+    B, H ,S, D, DV = 1,1,2048,D, 128
+    dtype = torch.float16 # performance regression for bfloat16
+    qkv_meta = (
+        meta_tensor(B, H, S, D, dtype=dtype),
+        meta_tensor(B, H, S, D, dtype=dtype),
+        meta_tensor(B, H, S, DV, dtype=dtype),
+    )
+
+    custom_fwd_inputs = CustomIO({
+        # "softmax_scale": (1,),
+    })
+
+    online = OnlineSoftmax()
+
+    mod = AttentionEngine(
+        qkv_meta,
+        custom_fwd_inputs, score_mod=score_mod, block_mask=block_sparse_mask,
+        online_func=online,
+        tune=False, tune_file="mha_tune.json",
+        infer_mask=True
+    )
+    # TODO: input mask的方式，tune mask的方式。
+
+    # test sliding window attention
+    torch.cuda.manual_seed(0)
+    q = torch.ones(B, S, H, D, dtype=dtype, device="cuda")
+    k = torch.ones(B, S, H, D, dtype=dtype, device="cuda")
+    v = torch.randn(B, S, H, DV, dtype=dtype, device="cuda")
+    o = mod(q,k,v)
+    from core.core import create_mask
+    mask = create_mask(block_sparse_mask, B, H, S, S, device="cuda")
+    print(mask)
+    def ref_attn(q,k,v):
+        attn = torch.einsum("bqhd,bkhd->bhqk", q, k)
+        attn = attn * (1/D ** 0.5)
+        attn = attn * mask
+        attn = attn.softmax(dim=-1)
+        return torch.einsum("bhqk,bkhd->bqhd", attn, v)
+    
+    ref_o = ref_attn(q,k,v)
+    with open("o.txt", "w") as f:
+        f.write(str(o))
+    with open("ref_o.txt", "w") as f:
+        f.write(str(ref_o))
+    print(torch.allclose(o, ref_o, atol=1e-2, rtol=1e-2))
+    

--- a/attn_script/gqa_inference.py
+++ b/attn_script/gqa_inference.py
@@ -1,0 +1,127 @@
+from attn_engine import AttentionEngine
+import torch
+import math
+from attn_engine import OnlineFunc
+from core.core import CustomIO
+from core.core import create_block_mask
+from core.core import SymbolicArray, SymbolScalar, SymbolicTensor
+from core.core import Var
+from core.utils import meta_tensor
+
+"""
+Example of attention decode with online softmax
+"""
+
+
+D = 128
+softmax_scale = 1/D ** 0.5
+# elementwise on attention scores
+def score_mod(score, custom_fwd_inputs, b, h, q_idx, kv_idx):
+    # softmax_scale = custom_fwd_inputs.input_tensors["softmax_scale"]
+    return score * softmax_scale
+
+class OnlineSoftmax(OnlineFunc):
+    def __init__(self):
+        """
+        define online_rowscales and final_rowscales
+        """
+        online_rowscales = {
+            "m": SymbolScalar("m", Var("-inf")), # -inf 
+            "r": SymbolScalar("r", Var("0.0")),
+        }
+        final_rowscales = {
+            "lse": SymbolScalar("lse", Var("0.0")), # not used in codegen
+        }
+        external_fwd_inputs = CustomIO()
+        # external_bwd_inputs = CustomIO({
+        #     "dppsum": (B,H,S),
+        # })
+        super().__init__(online_rowscales, final_rowscales,
+                    external_fwd_inputs) # , external_bwd_inputs)
+    
+
+    # scan
+    @staticmethod
+    def online_fwd(scores, online_rowscales, b, h, q_idx):
+
+        m , r = online_rowscales["m"], online_rowscales["r"]
+        m_new = m.max(scores.get_reduce("max"))
+        scale_tmp = (m - m_new).exp()
+        r = r * scale_tmp
+        
+        scores = (scores - m_new).exp()
+        r = r + scores.get_reduce("sum")
+
+        new_online_rowscales = {
+            "m": m_new,
+            "r": r,
+        }
+        o_scale = scale_tmp
+        return scores, new_online_rowscales, o_scale
+
+    # reduce
+    # @staticmethod
+    # def combine(online_rowscales, ):
+    #     m = online_rowscales["m"]
+    #     r = online_rowscales["r"]
+    #     m_max = m.get_reduce("max")
+    #     scale_tmp = (m - m_max).exp()
+    #     r_new = r * scale_tmp
+    #     r_sum = r_new.get_reduce("sum")
+    #     o_scale = scale_tmp / r_sum
+    #     return o_scale
+    
+    @staticmethod
+    def combine(final_rowscales, ):
+        lse = final_rowscales["lse"]
+        lse_max = lse.get_reduce("max")
+        row_sum = (lse - lse_max).exp()
+        row_sum_sum = row_sum.get_reduce("sum")
+        lse_sum = row_sum_sum.log() + lse_max
+        o_scale = (lse - lse_sum).exp()
+        return o_scale
+
+    @staticmethod
+    def online_fwd_epilogue(o, online_rowscales, b, h, q_idx):
+        o_new = o / online_rowscales["r"]
+        lse = (online_rowscales["r"]).log() + online_rowscales["m"]
+        final_rowscales = {
+            "lse": lse,
+        }
+        return o_new, final_rowscales
+
+    @staticmethod
+    def forward(scores, final_rowscales, b, h, q_idx, kv_idx):
+        lse = final_rowscales["lse"]
+        scores_new = (scores-lse).exp()
+        return scores_new
+    
+    @staticmethod
+    def backward(dp, scores, final_rowscales, doosum_rowscales, b, h, q_idx, kv_idx):
+        dppsum = doosum_rowscales # external_bwd_tensor.input_tensors["dppsum"]
+        dscores = (dp - dppsum)*scores # TODO: bug if swap
+        return dscores
+
+if __name__ == "__main__":
+    B, H, G ,S, D, DV = 1,32, 8,8192,D, 128
+    dtype = torch.float16 # performance regression for bfloat16
+    qkv_meta = (
+        meta_tensor(B, H, 1, D, dtype=dtype),
+        meta_tensor(B, G, S, D, dtype=dtype),
+        meta_tensor(B, G, S, DV, dtype=dtype),
+    )
+
+    custom_fwd_inputs = CustomIO({
+        # "softmax_scale": (1,),
+    })
+
+    online = OnlineSoftmax()
+    mod = AttentionEngine(
+        qkv_meta,
+        custom_fwd_inputs, score_mod=score_mod, block_mask=None,
+        online_func=online,
+        # tune=False, tune_file="mha_tune.json"
+    )
+
+    from benchmark.bench_utils import do_bench_attention
+    do_bench_attention(mod, B, H, S, D, DV, dtype=dtype, causal=False, seqlenq=1, groupnum=G)


### PR DESCRIPTION
This PR includes support for block sparse attention, similar to the mask API in `FlexAttention`. 
For example,
```py
BLOCK = 128
def block_sparse_mask(b, h, q_idx, kv_idx):
    return torch.logical_and(q_idx >= kv_idx, q_idx//BLOCK < kv_idx//BLOCK + 2)

```

Future TODOs:
- [ ] Support for arbitrary sparse mask, which need mask within single block.

